### PR TITLE
Feature/fix glyph null check

### DIFF
--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -121,9 +121,12 @@ namespace SharpMSDF.Demo
                     glyphs[g] = glyph;
                 }
 
-                // Add glyphs to atlas - invokes the underlying atlas generator
-                // Adding multiple glyphs at once may improve packing efficiency.
-                var changeFlags = myDynamicAtlas.Add(glyphs[prevEndMark..]);
+				var newGlyphs = glyphs[prevEndMark..];
+				var changeFlags = myDynamicAtlas.Add(newGlyphs);
+				for (int i = 0; i < newGlyphs.Count; ++i)
+				{
+					glyphs[prevEndMark + i] = newGlyphs[i];
+				}
 
                 var bitmap = myDynamicAtlas.Generator.Storage.Bitmap;
 

--- a/Source/IO/FontImporter.cs
+++ b/Source/IO/FontImporter.cs
@@ -124,13 +124,13 @@ namespace SharpMSDF.IO
         {
             //const double scale = 1.0 / 64;
             ushort glyphIndex = (ushort)typeface.GetGlyphIndex((int)unicode);
-            var glyph = typeface.GetGlyph(glyphIndex);
-            if (glyph == null)
-            {
-                advance = 0;
-                idealWidth = idealHeight = 0;
-                return new Shape();
-            }
+			if (glyphIndex == 0)
+			{
+				advance = 0;
+				idealWidth = idealHeight = 0;
+				return new Shape();
+			}
+			var glyph = typeface.GetGlyph(glyphIndex);
 
             int advUnits = typeface.GetAdvanceWidthFromGlyphIndex(glyphIndex);
 


### PR DESCRIPTION
Previous null check `(glyph == null)` was incorrect since if the glyph was not found a default glyph is returned, so this check never failed, fixed with proper check if the ID exists. This fixes an issue where placeholder char [] was being rendered for control chars such as `\r`.