### PR TITLE
Feature/refactor1

### DIFF
--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -121,9 +121,12 @@ namespace SharpMSDF.Demo
                     glyphs[g] = glyph;
                 }
 
-                // Add glyphs to atlas - invokes the underlying atlas generator
-                // Adding multiple glyphs at once may improve packing efficiency.
-                var changeFlags = myDynamicAtlas.Add(glyphs[prevEndMark..]);
+				var newGlyphs = glyphs[prevEndMark..];
+				var changeFlags = myDynamicAtlas.Add(newGlyphs);
+				for (int i = 0; i < newGlyphs.Count; ++i)
+				{
+					glyphs[prevEndMark + i] = newGlyphs[i];
+				}
 
                 var bitmap = myDynamicAtlas.Generator.Storage.Bitmap;
 

--- a/Source/Atlas/FontGeometry.cs
+++ b/Source/Atlas/FontGeometry.cs
@@ -79,7 +79,7 @@ namespace SharpMSDF.Atlas
             for (ushort index = rangeStart; index < rangeEnd; ++index)
             {
                 var glyph = new GlyphGeometry();
-                if (glyph.Load(ref glyph, font, geometryScale, index, preprocessGeometry))
+                if (glyph.Load(font, geometryScale, index, preprocessGeometry))
                 {
                     AddGlyph(glyph);
                     ++loaded;
@@ -105,7 +105,7 @@ namespace SharpMSDF.Atlas
             foreach (uint index in glyphset)
             {
                 var glyph = new GlyphGeometry();
-                if (glyph.Load(ref glyph, face, geometryScale, index, preprocessGeometry))
+                if (glyph.Load(face, geometryScale, index, preprocessGeometry))
                 {
                     AddGlyph(glyph);
                     ++loaded;
@@ -131,7 +131,7 @@ namespace SharpMSDF.Atlas
             foreach (uint cp in charset)
             {
                 var glyph = new GlyphGeometry();
-                if (glyph.Load(ref glyph, face, geometryScale, cp, preprocessGeometry))
+                if (glyph.Load(face, geometryScale, cp, preprocessGeometry))
                 {
                     AddGlyph(glyph);
                     ++loaded;

--- a/Source/Atlas/GlyphGeometry.cs
+++ b/Source/Atlas/GlyphGeometry.cs
@@ -37,9 +37,8 @@ namespace SharpMSDF.Atlas
 
         public GlyphGeometry() { }
 
-        public bool Load(ref GlyphGeometry self, Typeface font, double geometryScale, uint codepoint, bool preprocessGeometry = true)
+        public bool Load(Typeface font, double geometryScale, uint codepoint, bool preprocessGeometry = true)
         {
-            self = this;
             if (font == null)
                 return false;
 
@@ -68,12 +67,8 @@ namespace SharpMSDF.Atlas
                             contour.Reverse();
                     }
                 }
-
-                self = this;
                 return true;
             }
-
-            self = this;
             return false;
         }
 
@@ -82,7 +77,7 @@ namespace SharpMSDF.Atlas
             coloringFunc?.Invoke(_shape, angleThreshold, seed);
         }
 
-        public void WrapBox(ref GlyphGeometry self, GlyphAttributes glyphAttributes)
+        public void WrapBox(GlyphAttributes glyphAttributes)
         {
             double scale = glyphAttributes.Scale * _geometryScale;
             DoubleRange range = glyphAttributes.Range / _geometryScale;
@@ -140,34 +135,9 @@ namespace SharpMSDF.Atlas
                 _box.Rect.Height = 0;
                 _box.Translate = new Vector2();
             }
-            self = this;
         }
 
-        public void WrapBox(ref GlyphGeometry self, double scale, double range, double miterLimit, bool pxAlignOrigin)
-        {
-            WrapBox(ref self, new GlyphAttributes
-            {
-                Scale = scale,
-                Range = new DoubleRange(range),
-                MiterLimit = miterLimit,
-                PxAlignOriginX = pxAlignOrigin,
-                PxAlignOriginY = pxAlignOrigin
-            });
-        }
-
-        public void WrapBox(ref GlyphGeometry self, double scale, double range, double miterLimit, bool pxAlignOriginX, bool pxAlignOriginY)
-        {
-            WrapBox(ref self, new GlyphAttributes
-            {
-                Scale = scale,
-                Range = new DoubleRange(range),
-                MiterLimit = miterLimit,
-                PxAlignOriginX = pxAlignOriginX,
-                PxAlignOriginY = pxAlignOriginY
-            });
-        }
-
-        public void FrameBox(ref GlyphGeometry self, in GlyphAttributes glyphAttributes, int width, int height, double? fixedX, double? fixedY)
+        public void FrameBox(in GlyphAttributes glyphAttributes, int width, int height, double? fixedX, double? fixedY)
         {
             double scale = glyphAttributes.Scale * _geometryScale;
             DoubleRange range = glyphAttributes.Range / _geometryScale;
@@ -226,12 +196,11 @@ namespace SharpMSDF.Atlas
             }
 
             _box.OuterPadding = glyphAttributes.Scale * glyphAttributes.OuterPadding;
-            self = this;
         }
 
-        public void FrameBox(ref GlyphGeometry self, double scale, double range, double miterLimit, int width, int height, double? fixedX, double? fixedY, bool pxAlignOrigin)
+        public void FrameBox(double scale, double range, double miterLimit, int width, int height, double? fixedX, double? fixedY, bool pxAlignOrigin)
         {
-            FrameBox(ref self, new GlyphAttributes
+            FrameBox(new GlyphAttributes
             {
                 Scale = scale,
                 Range = new DoubleRange(range),
@@ -241,9 +210,9 @@ namespace SharpMSDF.Atlas
             }, width, height, fixedX, fixedY);
         }
 
-        public void FrameBox(ref GlyphGeometry self, double scale, double range, double miterLimit, int width, int height, double? fixedX, double? fixedY, bool pxAlignOriginX, bool pxAlignOriginY)
+        public void FrameBox(double scale, double range, double miterLimit, int width, int height, double? fixedX, double? fixedY, bool pxAlignOriginX, bool pxAlignOriginY)
         {
-            FrameBox(ref self, new GlyphAttributes
+            FrameBox(new GlyphAttributes
             {
                 Scale = scale,
                 Range = new DoubleRange(range),

--- a/Source/Atlas/TightAtlasPacker.cs
+++ b/Source/Atlas/TightAtlasPacker.cs
@@ -216,7 +216,7 @@ namespace SharpMSDF.Atlas
                     var g = glyphs[i];
                     if (!g.IsWhitespace())
                     {
-                        g.WrapBox(ref g, attribs);
+                        g.WrapBox(attribs);
                         g.GetBoxSize(out int rw, out int rh);
                         if (rw > 0 && rh > 0)
                         {

--- a/Source/Core/EdgeSelectors.cs
+++ b/Source/Core/EdgeSelectors.cs
@@ -366,7 +366,7 @@ namespace SharpMSDF.Core
 
     public class MultiAndTrueDistanceSelector : MultiDistanceSelector, IDistanceSelector<MultiAndTrueDistance>
     {
-        public MultiAndTrueDistance Distance()
+        new public MultiAndTrueDistance Distance()
         {
             var md = base.Distance();
             var td = base.TrueDistance();

--- a/Source/Core/MSDFErrorCorrection.cs
+++ b/Source/Core/MSDFErrorCorrection.cs
@@ -81,7 +81,7 @@ namespace SharpMSDF.Core
 
             /// Returns true if the combined results of the tests performed on the median value m interpolated at t indicate an artifact.
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public bool Evaluate(double t, float m, int flags)
+            new public bool Evaluate(double t, float m, int flags)
             {
                 if ((flags & CLASSIFIER_FLAG_CANDIDATE) != 0)
                 {

--- a/Source/Core/Shape.cs
+++ b/Source/Core/Shape.cs
@@ -6,7 +6,7 @@ using Typography.OpenFont.MathGlyphs;
 namespace SharpMSDF.Core
 {
 
-    public class Shape
+    public struct Shape
     {
         // Threshold of the dot product of adjacent edge directions to be considered convergent.
         public const double MSDFGEN_CORNER_DOT_EPSILON = .000001;
@@ -204,10 +204,15 @@ namespace SharpMSDF.Core
         }
 
         readonly static double _Ratio = 0.5 * (Math.Sqrt(5) - 1);
-        /// <summary>
-        /// Assumes its contours are unoriented (even-odd fill rule). Attempts to orient them to conform to the non-zero winding rule.
-        /// </summary>
-        public void OrientContours()
+
+		public Shape()
+		{
+		}
+
+		/// <summary>
+		/// Assumes its contours are unoriented (even-odd fill rule). Attempts to orient them to conform to the non-zero winding rule.
+		/// </summary>
+		public void OrientContours()
         {
             var orientations = new int[Contours.Count];
             var intersections = new List<Intersection>();

--- a/Source/IO/FontImporter.cs
+++ b/Source/IO/FontImporter.cs
@@ -124,13 +124,13 @@ namespace SharpMSDF.IO
         {
             //const double scale = 1.0 / 64;
             ushort glyphIndex = (ushort)typeface.GetGlyphIndex((int)unicode);
-            var glyph = typeface.GetGlyph(glyphIndex);
-            if (glyph == null)
-            {
-                advance = 0;
-                idealWidth = idealHeight = 0;
-                return new Shape();
-            }
+			if (glyphIndex == 0)
+			{
+				advance = 0;
+				idealWidth = idealHeight = 0;
+				return new Shape();
+			}
+			var glyph = typeface.GetGlyph(glyphIndex);
 
             int advUnits = typeface.GetAdvanceWidthFromGlyphIndex(glyphIndex);
 

--- a/Source/Typography.OpenFont/Tables.BitmapAndSvgFonts/CBDT.cs
+++ b/Source/Typography.OpenFont/Tables.BitmapAndSvgFonts/CBDT.cs
@@ -5,106 +5,105 @@ using Typography.OpenFont.Tables.BitmapFonts;
 
 namespace Typography.OpenFont.Tables
 {
-    //test font=> NotoColorEmoji.ttf
+	//test font=> NotoColorEmoji.ttf
 
-    //from https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt
+	//from https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt
 
-    //Table structure
+	//Table structure
 
-    //The CBDT table is used to embed color bitmap glyph data. It is used together with the CBLC table,
-    //which provides embedded bitmap locators.
-    //The formats of these two tables are backward compatible with the EBDT and EBLC tables
-    //used for embedded monochrome and grayscale bitmaps.
+	//The CBDT table is used to embed color bitmap glyph data. It is used together with the CBLC table,
+	//which provides embedded bitmap locators.
+	//The formats of these two tables are backward compatible with the EBDT and EBLC tables
+	//used for embedded monochrome and grayscale bitmaps.
 
-    //The CBDT table begins with a header containing simply the table version number.
-    //Type 	    Name 	        Description
-    //uint16 	majorVersion 	Major version of the CBDT table, = 3.
-    //uint16 	minorVersion 	Minor version of the CBDT table, = 0.
+	//The CBDT table begins with a header containing simply the table version number.
+	//Type 	    Name 	        Description
+	//uint16 	majorVersion 	Major version of the CBDT table, = 3.
+	//uint16 	minorVersion 	Minor version of the CBDT table, = 0.
 
-    //Note that the first version of the CBDT table is 3.0.
+	//Note that the first version of the CBDT table is 3.0.
 
-    //The rest of the CBDT table is a collection of bitmap data.
-    //The data can be presented in three possible formats,
-    //indicated by information in the CBLC table.
-    //Some of the formats contain metric information plus image data, 
-    //and other formats contain only the image data. Long word alignment is not required for these subtables;
-    //byte alignment is sufficient.
+	//The rest of the CBDT table is a collection of bitmap data.
+	//The data can be presented in three possible formats,
+	//indicated by information in the CBLC table.
+	//Some of the formats contain metric information plus image data, 
+	//and other formats contain only the image data. Long word alignment is not required for these subtables;
+	//byte alignment is sufficient.
 
-    class CBDT : TableEntry, IDisposable
-    {
-        public const string _N = "CBDT";
-        public override string Name => _N;
+	class CBDT : TableEntry, IDisposable
+	{
+		public const string _N = "CBDT";
+		public override string Name => _N;
 
-        readonly GlyphBitmapDataFmt17 _format17 = new GlyphBitmapDataFmt17();
-        readonly GlyphBitmapDataFmt18 _format18 = new GlyphBitmapDataFmt18();
-        readonly GlyphBitmapDataFmt19 _format19 = new GlyphBitmapDataFmt19();
+		readonly GlyphBitmapDataFmt17 _format17 = new GlyphBitmapDataFmt17();
+		readonly GlyphBitmapDataFmt18 _format18 = new GlyphBitmapDataFmt18();
+		readonly GlyphBitmapDataFmt19 _format19 = new GlyphBitmapDataFmt19();
 
 
-        System.IO.MemoryStream _ms; //sub-stream contains image data
-        Typography.OpenFont.ByteOrderSwappingBinaryReader _binReader;
+		System.IO.MemoryStream _ms; //sub-stream contains image data
+		Typography.OpenFont.ByteOrderSwappingBinaryReader _binReader;
 
-        public void Dispose()
-        {
-            RemoveOldMemoryStreamAndReaders();
-        }
+		public void Dispose()
+		{
+			RemoveOldMemoryStreamAndReaders();
+		}
 
-        public void RemoveOldMemoryStreamAndReaders()
-        {
-            try
-            {
-                if (_binReader != null)
-                {
-                    ((System.IDisposable)_binReader).Dispose();
-                    _binReader = null;
-                }
-                if (_ms != null)
-                {
-                    _ms.Dispose();
-                    _ms = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                //
-            }
-        }
-        protected override void ReadContentFrom(BinaryReader reader)
-        {
+		public void RemoveOldMemoryStreamAndReaders()
+		{
+			try
+			{
+				if (_binReader != null)
+				{
+					((System.IDisposable)_binReader).Dispose();
+					_binReader = null;
+				}
+				if (_ms != null)
+				{
+					_ms.Dispose();
+					_ms = null;
+				}
+			}
+			catch
+			{
+			}
+		}
+		protected override void ReadContentFrom(BinaryReader reader)
+		{
 
-            //we copy data from the input mem stream
-            //and store inside this table for later use.
-            RemoveOldMemoryStreamAndReaders();
+			//we copy data from the input mem stream
+			//and store inside this table for later use.
+			RemoveOldMemoryStreamAndReaders();
 
-            //-------------------
-            byte[] data = reader.ReadBytes((int)this.Header.Length);//***
-            _ms = new MemoryStream(data);
-            _binReader = new ByteOrderSwappingBinaryReader(_ms);
-        }
-        public void FillGlyphInfo(Glyph glyph)
-        {
-            //int srcOffset, int srcLen, int srcFormat,
-            _binReader.BaseStream.Position = glyph.BitmapStreamOffset;
-            switch (glyph.BitmapFormat)
-            {
-                case 17: _format17.FillGlyphInfo(_binReader, glyph); break;
-                case 18: _format18.FillGlyphInfo(_binReader, glyph); break;
-                case 19: _format19.FillGlyphInfo(_binReader, glyph); break;
-                default:
-                    throw new OpenFontNotSupportedException();
-            }
-        }
-        public void CopyBitmapContent(Glyph glyph, System.IO.Stream outputStream)
-        {
-            //1 
-            _binReader.BaseStream.Position = glyph.BitmapStreamOffset;
-            switch (glyph.BitmapFormat)
-            {
-                case 17: _format17.ReadRawBitmap(_binReader, glyph, outputStream); break;
-                case 18: _format18.ReadRawBitmap(_binReader, glyph, outputStream); break;
-                case 19: _format19.ReadRawBitmap(_binReader, glyph, outputStream); break;
-                default:
-                    throw new OpenFontNotSupportedException();
-            }
-        }
-    }
+			//-------------------
+			byte[] data = reader.ReadBytes((int)this.Header.Length);//***
+			_ms = new MemoryStream(data);
+			_binReader = new ByteOrderSwappingBinaryReader(_ms);
+		}
+		public void FillGlyphInfo(Glyph glyph)
+		{
+			//int srcOffset, int srcLen, int srcFormat,
+			_binReader.BaseStream.Position = glyph.BitmapStreamOffset;
+			switch (glyph.BitmapFormat)
+			{
+				case 17: _format17.FillGlyphInfo(_binReader, glyph); break;
+				case 18: _format18.FillGlyphInfo(_binReader, glyph); break;
+				case 19: _format19.FillGlyphInfo(_binReader, glyph); break;
+				default:
+					throw new OpenFontNotSupportedException();
+			}
+		}
+		public void CopyBitmapContent(Glyph glyph, System.IO.Stream outputStream)
+		{
+			//1 
+			_binReader.BaseStream.Position = glyph.BitmapStreamOffset;
+			switch (glyph.BitmapFormat)
+			{
+				case 17: _format17.ReadRawBitmap(_binReader, glyph, outputStream); break;
+				case 18: _format18.ReadRawBitmap(_binReader, glyph, outputStream); break;
+				case 19: _format19.ReadRawBitmap(_binReader, glyph, outputStream); break;
+				default:
+					throw new OpenFontNotSupportedException();
+			}
+		}
+	}
 }


### PR DESCRIPTION
New keyword was missing so abstract implementations were ignored, added those missing news.
Removed all instances of self=this and ref glyph, that was probably a weird artifact leftover from c++ to c# porting.