### PR TITLE
Feature/charset refactor

### DIFF
--- a/Source/Atlas/Charset.cs
+++ b/Source/Atlas/Charset.cs
@@ -1,44 +1,89 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections;
 
-namespace SharpMSDF.Atlas
+namespace SharpMSDF.Atlas;
+/// <summary>
+/// Represents a set of Unicode codepoints (characters)
+/// </summary>
+public struct Charset
 {
-    /// Represents a set of Unicode codepoints (characters)
-    public partial class Charset : IEnumerable<uint>
-    {
-        /// The set of the 95 printable ASCII characters
-        public readonly static Charset ASCII = CreateAsciiCharset();
+	private SortedSet<uint> _codepoints;
 
-        static Charset CreateAsciiCharset()
-        {
-            Charset ascii = new();
-            for (uint cp = 0x20; cp < 0x7f; ++cp)
-                ascii.Add(cp);
-            return ascii;
-        }
+	/// <summary>
+	/// The set of the 95 printable ASCII characters
+	/// </summary>
+	public static readonly SortedSet<uint> ASCII = CreateAsciiCharset();
 
-        /// <summary>
-        /// Adds a codepoint
-        /// </summary>
-        public void Add(uint cp) => _Codepoints.Add(cp);
-        /// <summary>
-        /// Removes a codepoint
-        /// </summary>
-        public void Remove(uint cp) => _Codepoints.Remove(cp);
+	private static SortedSet<uint> CreateAsciiCharset()
+	{
+		var ascii = new SortedSet<uint>();
+		for (uint cp = 0x20; cp < 0x7f; ++cp)
+		{
+			ascii.Add(cp);
+		}
+		return ascii;
+	}
 
-        public int Size() => _Codepoints.Count;
-        public bool Empty() => _Codepoints.Count == 0;
+	public Charset()
+	{
+		_codepoints = new SortedSet<uint>();
+	}
 
-        IEnumerator<uint> IEnumerable<uint>.GetEnumerator() => _Codepoints.GetEnumerator();
+	public Charset(SortedSet<uint> codepoints)
+	{
+		_codepoints = codepoints ?? new SortedSet<uint>();
+	}
 
-        IEnumerator IEnumerable.GetEnumerator() => _Codepoints.GetEnumerator();
+	/// <summary>
+	/// Adds a codepoint
+	/// </summary>
+	public void Add(uint cp)
+	{
+		_codepoints.Add(cp);
+	}
 
-        private SortedSet<uint> _Codepoints = [];
+	/// <summary>
+	/// Removes a codepoint
+	/// </summary>
+	public void Remove(uint cp)
+	{
+		_codepoints.Remove(cp);
+	}
 
-    };
+	public int Size()
+	{
+		return _codepoints.Count;
+	}
 
+	public bool Empty()
+	{
+		return _codepoints.Count == 0;
+	}
+
+	public SortedSet<uint>.Enumerator GetEnumerator()
+	{
+		return _codepoints.GetEnumerator();
+	}
+
+	public SortedSet<uint> GetCodepoints()
+	{
+		return _codepoints;
+	}
+
+	// Implicit conversion from ReadOnlySpan<char> to Charset
+	public static implicit operator Charset(ReadOnlySpan<char> chars)
+	{
+		var charset = new Charset();
+		foreach (char ch in chars)
+			charset.Add(ch);
+		return charset;
+	}
+
+	// Implicit conversion from ReadOnlySpan<uint> to Charset
+	public static implicit operator Charset(ReadOnlySpan<uint> codepoints)
+	{
+		var charset = new Charset();
+		foreach (uint cp in codepoints)
+			charset.Add(cp);
+		return charset;
+	}
 }

--- a/Source/Atlas/CharsetParser.cs
+++ b/Source/Atlas/CharsetParser.cs
@@ -1,341 +1,427 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
-namespace SharpMSDF.Atlas
+namespace SharpMSDF.Atlas;
+
+/// <summary>
+/// Static utility class for parsing charset files and strings
+/// </summary>
+public static class CharsetParser
 {
-    public partial class Charset
-    {
+	private enum State
+	{
+		Clear,
+		Tight,
+		RangeBracket,
+		RangeStart,
+		RangeSeparator,
+		RangeEnd
+	}
 
-        public bool Load(string filename, bool disableCharLiterals = false)
-        {
-            using FileStream fs = File.OpenRead(filename);
-            CharsetUserData userData = new(this, filename, disableCharLiterals, fs);
-            return CharsetParse(userData, CharsetUserData.ReadChar, CharsetUserData .Add, CharsetUserData.Include, disableCharLiterals, false);
-        }
+	public delegate int ReadCharFunc<T>(ref T userData);
 
-        public unsafe bool Parse(string str, bool disableCharLiterals = false)
-        {
-            fixed (char* chars = str)
-            {
-                CharsetUserData userData = new(this, &chars[0], &chars[str.Length]);
-                return CharsetParse(userData, CharsetUserData.ReadChar, CharsetUserData.Add, CharsetUserData.Include, disableCharLiterals, true);
-            }
-        }
+	public unsafe struct ParseUserData
+	{
+		public char* Cur;
+		public char* End;
 
-        public static char EscapedChar(char c) => c switch
-        {
-            '0' => '\0',
-            'n' or 'N' => '\n',
-            'r' or 'R' => '\r',
-            's' or 'S' => ' ',
-            't' or 'T' => '\t',
-            _ => c
-        };
+		public ParseUserData(char* cur, char* end)
+		{
+			Cur = cur;
+			End = end;
+		}
 
-        public static bool ParseInt(string str, out int result)
-        {
-            result = 0;
-            if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
-            {
-                for (int i = 2; i < str.Length; ++i)
-                {
-                    char c = str[i];
-                    if (c is >= '0' and <= '9')
-                        result = (result << 4) + (c - '0');
-                    else if (c is >= 'A' and <= 'F')
-                        result = (result << 4) + (c - 'A' + 10);
-                    else if (c is >= 'a' and <= 'f')
-                        result = (result << 4) + (c - 'a' + 10);
-                    else
-                        return false;
-                }
-                return true;
-            }
-            else
-            {
-                foreach (char c in str)
-                {
-                    if (c is >= '0' and <= '9')
-                        result = result * 10 + (c - '0');
-                    else
-                        return false;
-                }
-                return true;
-            }
-        }
+		public static int ReadChar(ref ParseUserData ud)
+		{
+			return ud.Cur < ud.End ? *ud.Cur++ : -1;
+		}
+	}
 
-        private enum State
-        {
-            Clear,
-            Tight,
-            RangeBracket,
-            RangeStart,
-            RangeSeparator,
-            RangeEnd
-        }
+	public readonly struct LoadUserData
+	{
+		public readonly string Filename;
+		public readonly bool DisableCharLiterals;
+		public readonly FileStream File;
 
-        public static bool CharsetParse(
-           CharsetUserData userData,
-           ReadCharFunc readChar,
-           Action<CharsetUserData, uint> add,
-           Func<CharsetUserData, string, bool> include,
-           bool disableCharLiterals,
-           bool disableInclude
-       )
-        {
-            State state = State.Clear;
-            var buffer = new StringBuilder();
-            var unicodeBuffer = new List<uint>();
-            uint rangeStart = 0;
-            bool start = true;
+		public LoadUserData(string filename, bool disableCharLiterals, FileStream file)
+		{
+			Filename = filename;
+			DisableCharLiterals = disableCharLiterals;
+			File = file;
+		}
 
-            for (int c = readChar(ref userData); c >= 0; start = false, c = readChar(ref userData))
-            {
-                switch (c)
-                {
-                    // --- Number literal ---
-                    case >= '0' and <= '9':
-                        if (state is not (State.Clear or State.RangeBracket or State.RangeSeparator))
-                            return false;
-                        buffer.Append((char)c);
-                        c = ReadWord(readChar, userData, buffer);
-                        if (!ParseInt(buffer.ToString(), out int cp))
-                            return false;
-                        switch (state)
-                        {
-                            case State.Clear:
-                                if (cp >= 0) add(userData, (uint)cp);
-                                state = State.Tight;
-                                break;
-                            case State.RangeBracket:
-                                rangeStart = (uint)cp;
-                                state = State.RangeStart;
-                                break;
-                            case State.RangeSeparator:
-                                for (uint u = rangeStart; u <= (uint)cp; ++u)
-                                    add(userData, u);
-                                state = State.RangeEnd;
-                                break;
-                        }
-                        buffer.Clear();
-                        continue; // already have next c
+		public static int ReadChar(ref LoadUserData ud)
+		{
+			return ud.File.ReadByte();
+		}
+	}
 
-                    // --- Single char literal ---
-                    case '\'':
-                        if (!(state is State.Clear or State.RangeBracket or State.RangeSeparator) || disableCharLiterals)
-                            return false;
-                        if (!ReadString(readChar, userData, buffer, '\''))
-                            return false;
-                        Utf8.Utf8Decode(unicodeBuffer, buffer.ToString());
-                        if (unicodeBuffer.Count != 1)
-                            return false;
-                        uint uc = unicodeBuffer[0];
-                        switch (state)
-                        {
-                            case State.Clear:
-                                if (uc > 0) add(userData, uc);
-                                state = State.Tight;
-                                break;
-                            case State.RangeBracket:
-                                rangeStart = uc;
-                                state = State.RangeStart;
-                                break;
-                            case State.RangeSeparator:
-                                for (uint u = rangeStart; u <= uc; ++u)
-                                    add(userData, u);
-                                state = State.RangeEnd;
-                                break;
-                        }
-                        unicodeBuffer.Clear();
-                        buffer.Clear();
-                        break;
+	/// <summary>
+	/// Loads a charset from a file
+	/// </summary>
+	public static bool LoadFromFile(ref Charset charset, string filename, bool disableCharLiterals = false)
+	{
+		using var fs = File.OpenRead(filename);
+		var userData = new LoadUserData(filename, disableCharLiterals, fs);
+		return Parse(ref charset, ref userData, LoadUserData.ReadChar, disableCharLiterals, false);
+	}
 
-                    // --- String literal ---
-                    case '"':
-                        if (state != State.Clear || disableCharLiterals)
-                            return false;
-                        if (!ReadString(readChar, userData, buffer, '"'))
-                            return false;
-                        Utf8.Utf8Decode(unicodeBuffer, buffer.ToString());
-                        foreach (var cp2 in unicodeBuffer)
-                            add(userData, cp2);
-                        unicodeBuffer.Clear();
-                        buffer.Clear();
-                        state = State.Tight;
-                        break;
+	/// <summary>
+	/// Parses a charset from a string
+	/// </summary>
+	public static unsafe bool ParseFromString(ref Charset charset, string str, bool disableCharLiterals = false)
+	{
+		fixed (char* chars = str)
+		{
+			var userData = new ParseUserData(&chars[0], &chars[str.Length]);
+			return Parse(ref charset, ref userData, ParseUserData.ReadChar, disableCharLiterals, true);
+		}
+	}
 
-                    // --- Range brackets ---
-                    case '[':
-                        if (state != State.Clear) return false;
-                        state = State.RangeBracket;
-                        break;
-                    case ']':
-                        if (state == State.RangeEnd) state = State.Tight;
-                        else return false;
-                        break;
+	/// <summary>
+	/// Core parsing logic
+	/// </summary>
+	private static bool Parse<T>(
+		ref Charset charset,
+		ref T userData,
+		ReadCharFunc<T> readChar,
+		bool disableCharLiterals,
+		bool disableInclude)
+	{
+		var state = State.Clear;
+		var buffer = new StringBuilder();
+		var unicodeBuffer = new List<uint>();
+		uint rangeStart = 0;
+		bool start = true;
 
-                    // --- Include directive ---
-                    case '@':
-                        if (state != State.Clear) return false;
-                        c = ReadWord(readChar, userData, buffer);
-                        if (buffer.ToString() == "include")
-                        {
-                            // skip whitespace
-                            while (c is ' ' or '\t' or '\n' or '\r')
-                                c = readChar(ref userData);
-                            if (c != '"') return false;
-                            buffer.Clear();
-                            if (!ReadString(readChar, userData, buffer, '"'))
-                                return false;
-                            if (!disableInclude)
-                                include(userData, buffer.ToString());
-                            state = State.Tight;
-                        }
-                        else return false;
-                        buffer.Clear();
-                        break;
+		for (int c = readChar(ref userData); c >= 0; start = false, c = readChar(ref userData))
+		{
+			switch (c)
+			{
+				// --- Number literal ---
+				case >= '0' and <= '9':
+					if (state is not (State.Clear or State.RangeBracket or State.RangeSeparator))
+					{
+						return false;
+					}
 
-                    // --- Separators & whitespace ---
-                    case ',':
-                    case ';':
-                        if (state is State.RangeStart)
-                            state = State.RangeSeparator;
-                        else if (state is not (State.Clear or State.Tight))
-                            return false;
-                        goto case ' ';
-                    case ' ':
-                    case '\n':
-                    case '\r':
-                    case '\t':
-                        if (state == State.Tight)
-                            state = State.Clear;
-                        break;
+					buffer.Append((char)c);
+					c = ReadWord(readChar, ref userData, buffer);
+					if (!ParseInt(buffer.ToString(), out int cp))
+					{
+						return false;
+					}
 
-                    // --- BOM at start ---
-                    case 0xEF:
-                        if (start &&
-                            readChar(ref userData) == 0xBB &&
-                            readChar(ref userData) == 0xBF)
-                        {
-                            break;
-                        }
-                        return false;
+					switch (state)
+					{
+						case State.Clear:
+							if (cp >= 0)
+							{
+								charset.Add((uint)cp);
+							}
+							state = State.Tight;
+							break;
+						case State.RangeBracket:
+							rangeStart = (uint)cp;
+							state = State.RangeStart;
+							break;
+						case State.RangeSeparator:
+							for (uint u = rangeStart; u <= (uint)cp; ++u)
+							{
+								charset.Add(u);
+							}
+							state = State.RangeEnd;
+							break;
+					}
+					buffer.Clear();
+					continue; // already have next c
 
-                    // --- Anything else is error ---
-                    default:
-                        return false;
-                }
-            }
+				// --- Single char literal ---
+				case '\'':
+					if (!(state is State.Clear or State.RangeBracket or State.RangeSeparator) || disableCharLiterals)
+					{
+						return false;
+					}
 
-            return state == State.Clear || state == State.Tight;
-        }
+					if (!ReadString(readChar, ref userData, buffer, '\''))
+					{
+						return false;
+					}
 
+					Utf8.Utf8Decode(unicodeBuffer, buffer.ToString());
+					if (unicodeBuffer.Count != 1)
+					{
+						return false;
+					}
 
-        private static bool ReadString(ReadCharFunc readChar, CharsetUserData userData, StringBuilder buffer, char terminator)
-        {
-            bool escape = false;
-            while (true)
-            {
-                int ci = readChar(ref userData);
-                if (ci < 0) return false;
-                char c = (char)ci;
-                if (escape)
-                {
-                    buffer.Append(EscapedChar(c));
-                    escape = false;
-                }
-                else
-                {
-                    if (c == terminator) return true;
-                    if (c == '\\') { escape = true; }
-                    else buffer.Append(c);
-                }
-            }
-        }
+					uint uc = unicodeBuffer[0];
+					switch (state)
+					{
+						case State.Clear:
+							if (uc > 0)
+							{
+								charset.Add(uc);
+							}
+							state = State.Tight;
+							break;
+						case State.RangeBracket:
+							rangeStart = uc;
+							state = State.RangeStart;
+							break;
+						case State.RangeSeparator:
+							for (uint u = rangeStart; u <= uc; ++u)
+							{
+								charset.Add(u);
+							}
+							state = State.RangeEnd;
+							break;
+					}
+					unicodeBuffer.Clear();
+					buffer.Clear();
+					break;
 
-        public static string CombinePath(string basePath, string relPath)
-        {
-            if (Path.IsPathRooted(relPath))
-                return relPath;
+				// --- String literal ---
+				case '"':
+					if (state != State.Clear || disableCharLiterals)
+					{
+						return false;
+					}
 
-            string? dir = Path.GetDirectoryName(basePath);
-            return dir != null ? Path.Combine(dir, relPath) : relPath;
-        }
+					if (!ReadString(readChar, ref userData, buffer, '"'))
+					{
+						return false;
+					}
 
-        private static int ReadWord(ReadCharFunc readChar, CharsetUserData userData, StringBuilder buffer)
-        {
-            while (true)
-            {
-                int c = readChar(ref userData);
-                if (char.IsLetterOrDigit((char)c) || c == '_')
-                    buffer.Append((char)c);
-                else
-                    return c;
-            }
-        }
-    }
+					Utf8.Utf8Decode(unicodeBuffer, buffer.ToString());
+					foreach (uint cp2 in unicodeBuffer)
+					{
+						charset.Add(cp2);
+					}
 
-    public delegate int ReadCharFunc(ref CharsetUserData charset);
+					unicodeBuffer.Clear();
+					buffer.Clear();
+					state = State.Tight;
+					break;
 
-    public unsafe struct CharsetUserData
-    {
-        public Charset Charset { get; set; }
-        
-        public readonly bool IsParseNotLoad;
+				// --- Range brackets ---
+				case '[':
+					if (state != State.Clear)
+					{
+						return false;
+					}
+					state = State.RangeBracket;
+					break;
+				case ']':
+					if (state == State.RangeEnd)
+					{
+						state = State.Tight;
+					}
+					else
+					{
+						return false;
+					}
+					break;
 
-        // Parse
-        public char* Cur;
-        public char* End;
+				// --- Include directive ---
+				case '@':
+					if (state != State.Clear)
+					{
+						return false;
+					}
 
-        // Load
-        public string Filename;
-        public bool DisableCharLiterals;
-        public FileStream File;
+					c = ReadWord(readChar, ref userData, buffer);
+					if (buffer.ToString() == "include")
+					{
+						// skip whitespace
+						while (c is ' ' or '\t' or '\n' or '\r')
+						{
+							c = readChar(ref userData);
+						}
 
-        public CharsetUserData(Charset charset, char* cur, char* end)
-        {
-            IsParseNotLoad = true;
-            Charset = charset;
-            Cur = cur;
-            End = end;
-        }
-        public CharsetUserData(Charset charset, string filename, bool disableCharLiterals, FileStream file)
-        {
-            IsParseNotLoad = false;
-            Charset = charset;
-            Filename = filename;
-            DisableCharLiterals = disableCharLiterals;
-            File = file;
-        }
+						if (c != '"')
+						{
+							return false;
+						}
 
-        public static int ReadChar(ref CharsetUserData ud)
-        {
-            if (ud.IsParseNotLoad)
-            {
-                // sus
-                return ud.Cur < ud.End ? *ud.Cur++ : -1;
-            }
+						buffer.Clear();
+						if (!ReadString(readChar, ref userData, buffer, '"'))
+						{
+							return false;
+						}
 
-            return ud.File.ReadByte();
-        }
+						if (!disableInclude && userData is LoadUserData loadData)
+						{
+							string fullPath = CombinePath(loadData.Filename, buffer.ToString());
+							LoadFromFile(ref charset, fullPath, loadData.DisableCharLiterals);
+						}
 
-        public static void Add(CharsetUserData ud, uint codepoint)
-        {
-            ud.Charset.Add(codepoint);
-        }
+						state = State.Tight;
+					}
+					else
+					{
+						return false;
+					}
 
-        public static bool Include(CharsetUserData ud, string path)
-        {
-            if (ud.IsParseNotLoad)
-                return false;
+					buffer.Clear();
+					break;
 
-            string fullPath = Charset.CombinePath(ud.Filename, path);
-            return ud.Charset.Load(fullPath, ud.DisableCharLiterals);
-        }
-    }
+				// --- Separators & whitespace ---
+				case ',':
+				case ';':
+					if (state is State.RangeStart)
+					{
+						state = State.RangeSeparator;
+					}
+					else if (state is not (State.Clear or State.Tight))
+					{
+						return false;
+					}
+					goto case ' ';
+				case ' ':
+				case '\n':
+				case '\r':
+				case '\t':
+					if (state == State.Tight)
+					{
+						state = State.Clear;
+					}
+					break;
+
+				// --- BOM at start ---
+				case 0xEF:
+					if (start &&
+						readChar(ref userData) == 0xBB &&
+						readChar(ref userData) == 0xBF)
+					{
+						break;
+					}
+					return false;
+
+				// --- Anything else is error ---
+				default:
+					return false;
+			}
+		}
+
+		return state is State.Clear or State.Tight;
+	}
+
+	public static char EscapedChar(char c)
+	{
+		return c switch
+		{
+			'0' => '\0',
+			'n' or 'N' => '\n',
+			'r' or 'R' => '\r',
+			's' or 'S' => ' ',
+			't' or 'T' => '\t',
+			_ => c
+		};
+	}
+
+	public static bool ParseInt(string str, out int result)
+	{
+		result = 0;
+		if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+		{
+			for (int i = 2; i < str.Length; ++i)
+			{
+				char c = str[i];
+				if (c is >= '0' and <= '9')
+				{
+					result = (result << 4) + (c - '0');
+				}
+				else if (c is >= 'A' and <= 'F')
+				{
+					result = (result << 4) + c - 'A' + 10;
+				}
+				else if (c is >= 'a' and <= 'f')
+				{
+					result = (result << 4) + c - 'a' + 10;
+				}
+				else
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+		else
+		{
+			foreach (char c in str)
+			{
+				if (c is >= '0' and <= '9')
+				{
+					result = (result * 10) + (c - '0');
+				}
+				else
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
+	private static bool ReadString<T>(ReadCharFunc<T> readChar, ref T userData, StringBuilder buffer, char terminator)
+	{
+		bool escape = false;
+		while (true)
+		{
+			int ci = readChar(ref userData);
+			if (ci < 0)
+			{
+				return false;
+			}
+
+			char c = (char)ci;
+			if (escape)
+			{
+				buffer.Append(EscapedChar(c));
+				escape = false;
+			}
+			else
+			{
+				if (c == terminator)
+				{
+					return true;
+				}
+
+				if (c == '\\')
+				{
+					escape = true;
+				}
+				else
+				{
+					buffer.Append(c);
+				}
+			}
+		}
+	}
+
+	public static string CombinePath(string basePath, string relPath)
+	{
+		if (Path.IsPathRooted(relPath))
+		{
+			return relPath;
+		}
+
+		string? dir = Path.GetDirectoryName(basePath);
+		return dir != null ? Path.Combine(dir, relPath) : relPath;
+	}
+
+	private static int ReadWord<T>(ReadCharFunc<T> readChar, ref T userData, StringBuilder buffer)
+	{
+		while (true)
+		{
+			int c = readChar(ref userData);
+			if (char.IsLetterOrDigit((char)c) || c == '_')
+			{
+				buffer.Append((char)c);
+			}
+			else
+			{
+				return c;
+			}
+		}
+	}
 }

--- a/Source/Atlas/FontGeometry.cs
+++ b/Source/Atlas/FontGeometry.cs
@@ -122,7 +122,7 @@ namespace SharpMSDF.Atlas
         /// <summary>
         /// Loads all glyphs in a charset (Charset elements are Unicode codepoints), returns the number of successfully loaded glyphs
         /// </summary>
-        public int LoadCharset(Typeface face, double fontScale, ReadOnlySpan<char> charset, bool preprocessGeometry = true, bool enableKerning = true)
+        public int LoadCharset(Typeface face, double fontScale, Charset charset, bool preprocessGeometry = true, bool enableKerning = true)
         {
             if (!(glyphs.Count == rangeEnd && LoadMetrics(face, fontScale)))
                 return -1;


### PR DESCRIPTION
Seperated out the charset and charset processors concerns, one is strictly stack allocated charset data, the other is strictly static helper functions for parsing.

Additionally impliciter operators are implemented so you can provide ReadOnlySpan<char> directly as well, which will be implicitly converted to CharSet, again without heap allocation.